### PR TITLE
Use async start and stop methods for the language client

### DIFF
--- a/src/platform/languageClientApi.nim
+++ b/src/platform/languageClientApi.nim
@@ -41,7 +41,7 @@ proc newLanguageClient*(
   serverOptions: ServerOptions,
   clientOptions: LanguageClientOptions): VscodeLanguageClient {.importcpp: "(new #.LanguageClient(@))".}
 
-proc start*(s: VscodeLanguageClient): void {.importcpp: "#.start()".}
-proc stop*(s: VscodeLanguageClient): void {.importcpp: "#.stop()".}
+proc start*(s: VscodeLanguageClient): Promise[void] {.importcpp: "#.start()".}
+proc stop*(s: VscodeLanguageClient): Promise[void] {.importcpp: "#.stop()".}
 
 var vscodeLanguageClient*: VscodeLanguageClient = require("vscode-languageclient/node").to(VscodeLanguageClient)


### PR DESCRIPTION
This is needed after the following breaking change in the vscode-languageserver-node package:

https://github.com/microsoft/vscode-languageserver-node#3170-protocol-800-json-rpc-800-client-and-800-server