### PR TITLE
Use the Nim language server by default, instead of nimsuggest directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
                 },
                 "nim.provider": {
                     "type": "string",
-                    "default": "nimsuggest",
+                    "default": "lsp",
                     "description": "The backend to use for language features.",
                     "enum": [
                         "nimsuggest",


### PR DESCRIPTION
Use the Nim language server by default, instead of nimsuggest directly, as the language server offers a better functionality (for example, inlay hints)