### PR TITLE
+ show an error notification if, during nimlangserver version detection, the

### DIFF
--- a/src/platform/vscodeApi.nim
+++ b/src/platform/vscodeApi.nim
@@ -623,6 +623,7 @@ proc with*(uri: VscodeUri, change: VscodeUriChange): VscodeUri {.importcpp.}
 # Output
 proc showInformationMessage*(win: VscodeWindow, msg: cstring) {.importcpp.}
     ## shows an informational message
+proc showErrorMessage*(win: VscodeWindow, message: cstring) {.importcpp.}
 
 # Workspace
 proc saveAll*(ws: VscodeWorkspace, includeUntitledFile: bool): Future[bool] {.importcpp.}


### PR DESCRIPTION
  nimlangserver process terminates with an error. Include the stdout and stderr
  output in the error notification. This shows errors, such as missing .so files
  to the user like this:
    Error starting nimlangserver: could not load: lipcre.so(.3|1)
    (compile with -d:nimDebugDlOpen for more information)
  Previously, these errors would not be shown to the user, and instead a
  spurious and misleading "There is a new Nim langserver version available"
  message would be shown. The actual error would be well hidden under the
  "Nim Language Server" tab in the Output window, which is not normally shown,
  unless the user specifically opens this window.