### PR TITLE
+ if nimlangserver is not found, ask the user before attempting to 'nimble install' it.

### DIFF
--- a/src/nimLsp.nim
+++ b/src/nimLsp.nim
@@ -129,12 +129,14 @@ proc startLanguageServer(tryInstall: bool, state: ExtensionState) {.async.} =
       .then(
         onfulfilled = proc(value: JsRoot): JsRoot =
           if value.JsObject.to(VscodeMessageItem).title == "Yes":
-            discard cp.exec(
-              command,
-              ExecOptions{},
-              proc(err: ExecError, stdout: cstring, stderr: cstring): void {.async.} =
-                console.log("Nimble install finished, validating by checking if nimlangserver is present.")
-                await startLanguageServer(false, state))
+            if not state.installPerformed:
+              state.installPerformed = true
+              discard cp.exec(
+                command,
+                ExecOptions{},
+                proc(err: ExecError, stdout: cstring, stderr: cstring): void {.async.} =
+                  console.log("Nimble install finished, validating by checking if nimlangserver is present.")
+                  await startLanguageServer(false, state))
           value
         ,
         onrejected = proc(reason: JsRoot): JsRoot =

--- a/src/nimLsp.nim
+++ b/src/nimLsp.nim
@@ -119,14 +119,27 @@ proc startLanguageServer(tryInstall: bool, state: ExtensionState) {.async.} =
     if tryInstall and not state.installPerformed:
       let command = getNimbleExecPath() & " install nimlangserver --accept"
       vscode.window.showInformationMessage(
-        cstring(fmt "Unable to find nimlangserver, trying to install it via '{command}'"))
-      state.installPerformed = true
-      discard cp.exec(
-        command,
-        ExecOptions{},
-        proc(err: ExecError, stdout: cstring, stderr: cstring): void {.async.} =
-          console.log("Nimble install finished, validating by checking if nimlangserver is present.")
-          await startLanguageServer(false, state))
+        cstring(fmt "Unable to find nimlangserver. Do you want me to attempt to install it via '{command}'?"),
+        VscodeMessageOptions(
+          detail: cstring(""),
+          modal: false
+        ),
+        VscodeMessageItem(title: cstring("Yes"), isCloseAffordance: false),
+        VscodeMessageItem(title: cstring("No"), isCloseAffordance: true))
+      .then(
+        onfulfilled = proc(value: JsRoot): JsRoot =
+          if value.JsObject.to(VscodeMessageItem).title == "Yes":
+            discard cp.exec(
+              command,
+              ExecOptions{},
+              proc(err: ExecError, stdout: cstring, stderr: cstring): void {.async.} =
+                console.log("Nimble install finished, validating by checking if nimlangserver is present.")
+                await startLanguageServer(false, state))
+          value
+        ,
+        onrejected = proc(reason: JsRoot): JsRoot =
+          reason
+      )
     else:
       let cantInstallInfoMesssage: cstring = "Unable to find/install `nimlangserver`. You can attempt to install it by running `nimble install nimlangserver` or downloading the binaries from https://github.com/nim-lang/langserver/releases."
       vscode.window.showInformationMessage(cantInstallInfoMesssage)

--- a/src/nimLsp.nim
+++ b/src/nimLsp.nim
@@ -131,6 +131,8 @@ proc startLanguageServer(tryInstall: bool, state: ExtensionState) {.async.} =
           if value.JsObject.to(VscodeMessageItem).title == "Yes":
             if not state.installPerformed:
               state.installPerformed = true
+              vscode.window.showInformationMessage(
+                cstring(fmt "Trying to install nimlangserver via '{command}'"))
               discard cp.exec(
                 command,
                 ExecOptions{},

--- a/src/platform/vscodeApi.nim
+++ b/src/platform/vscodeApi.nim
@@ -6,6 +6,9 @@ export jsffi, jsPromise, jsNode
 ## TODO: Move from JsObject to JsRoot for more explict errors
 
 type
+  VscodeThenable* = ref VscodeThenableObj
+  VscodeThenableObj {.importc.} = object of JsRoot
+
   VscodeMarkdownString* = ref VscodeMarkdownStringObj
   VscodeMarkdownStringObj {.importc.} = object of JsObject
     value*: cstring
@@ -183,6 +186,8 @@ type
 
   VscodeMarkedString* = ref VscodeMarkedStringObj
   VscodeMarkedStringObj {.importc.} = object of JsObject
+
+proc then*(self: VscodeThenable, onfulfilled: proc(value: JsRoot): JsRoot, onrejected: proc(reason: JsRoot): JsRoot): VscodeThenable {.importcpp, discardable.}
 
 proc cstringToMarkedString(s: cstring): VscodeMarkedString {.importcpp: "#".}
 converter toVscodeMarkedString*(s: cstring): VscodeMarkedString = s.cstringToMarkedString()
@@ -492,6 +497,16 @@ type
     activeTextEditor*: VscodeTextEditor
     visibleTextEditors*: Array[VscodeTextEditor]
 
+  VscodeMessageItem* = ref VscodeMessageItemObj
+  VscodeMessageItemObj {.importc.} = object of JsRoot
+    isCloseAffordance*: bool
+    title*: cstring
+
+  VscodeMessageOptions* = ref VscodeMessageOptionsObj
+  VscodeMessageOptionsObj {.importc.} = object of JsRoot
+    detail*: cstring
+    modal*: bool
+
   VscodeCommands* = ref VscodeCommandsObj
   VscodeCommandsObj {.importc.} = object of JsObject
 
@@ -622,6 +637,7 @@ proc with*(uri: VscodeUri, change: VscodeUriChange): VscodeUri {.importcpp.}
 
 # Output
 proc showInformationMessage*(win: VscodeWindow, msg: cstring) {.importcpp.}
+proc showInformationMessage*(win: VscodeWindow, message: cstring, options: VscodeMessageOptions): VscodeThenable {.importcpp, varargs, discardable.}
     ## shows an informational message
 proc showErrorMessage*(win: VscodeWindow, message: cstring) {.importcpp.}
 


### PR DESCRIPTION
I don't like plugins that auto install stuff without asking me. I might want to install nimlangserver through other means, such as the distro package manager. Or maybe I'm working on the nimlangserver itself, and I have a working development version, but I forgot to add it to the PATH. Or maybe I want to install it manually from the console, so I can inspect any build messages and debug issues. In such cases, I don't want stuff auto installed in my home directory. And people who do want that, can simply click "Yes" in the dialog shown.

Screenshot of the new dialog:
![image](https://github.com/nim-lang/vscode-nim/assets/22420132/26e72ea0-6e1e-463c-b844-f10fcae00c2e)
