### PR TITLE
Remove several compilation warnings

### DIFF
--- a/src/nimLsp.nim
+++ b/src/nimLsp.nim
@@ -3,7 +3,6 @@ import platform/[vscodeApi, languageClientApi]
 
 import platform/js/[jsNodeFs, jsNodePath, jsNodeCp, jsNodeUtil, jsNodeOs]
 import nimutils
-from std/strformat import fmt
 from tools/nimBinTools import getNimbleExecPath, getBinPath
 import spec
 
@@ -313,7 +312,7 @@ proc stopLanguageServer(state: ExtensionState) {.async.} =
   await state.client.stop()
 
 proc getWebviewContent(status: NimLangServerStatus): cstring =
-  result = &"""
+  result = cstring(&"""
   <!DOCTYPE html>
   <html lang="en">
   <head>
@@ -348,7 +347,7 @@ proc getWebviewContent(status: NimLangServerStatus): cstring =
     </div>
   </body>
   </html>
-  """
+  """)
 
 proc displayStatusInWebview(status: NimLangServerStatus)  =
   let panel = vscode.window.createWebviewPanel("nim", "Nim", ViewColumn.one, WebviewPanelOptions())
@@ -372,7 +371,7 @@ proc newLspItem*(label: cstring, description: cstring = "", tooltip: cstring = "
 
 proc onShowNotification*(args: JsObject) =
   let message = args.to(cstring)
-  vscode.window.showInformationMessage("Details", VscodeMessageOptions(detail: args.to(cstring), modal: true))
+  vscode.window.showInformationMessage("Details", VscodeMessageOptions(detail: message, modal: true))
 
 proc onDeleteNotification*(args: JsObject) =
   let id = args.to(cstring)
@@ -487,7 +486,7 @@ proc newNimLangServerStatusProvider*(): NimLangServerStatusProvider =
   provider.status = none(NimLangServerStatus)
   provider.notifications = @[]
   provider.lastId = 1
-  provider.getTreeItem = proc (element: TreeItem): Future[TreeItem]  =
+  provider.getTreeItem = proc (element: TreeItem): Future[TreeItem] =
     getTreeItemImpl(provider, element)
   provider.getChildren = proc (element: LspItem): seq[LspItem] = 
      getChildrenImpl(provider, element)

--- a/src/nimvscode.nim
+++ b/src/nimvscode.nim
@@ -7,7 +7,6 @@ import platform/vscodeApi
 import platform/js/[jsre, jsString, jsNodeFs, jsNodePath, jsNodeCp]
 import tools/nimBinTools
 import std/[strformat, jsconsole, strutils, options]
-from std/strformat import fmt
 from std/os import `/`
 import spec
 import nimRename,
@@ -300,7 +299,7 @@ proc debugFile() =
     typ = config.getStr("debug.type")
     editor = vscode.window.activeTextEditor
     filename = editor.document.fileName
-    filePath  = path.join(outputDirConfig, path.basename(editor.document.fileName).replace(".nim", ""))
+    filePath = path.join(outputDirConfig, path.basename(editor.document.fileName).replace(".nim", ""))
     workspaceFolder = vscode.workspace.getWorkspaceFolder(editor.document.uri)
   #compiles the file
   runFile(ignore = false, isDebug = true)

--- a/src/tools/nimBinTools.nim
+++ b/src/tools/nimBinTools.nim
@@ -28,7 +28,7 @@ proc getBinPath*(tool: cstring, initialSearchPaths: openArray[cstring] = []): cs
     let paths = pathParts.mapIt(
         block:
           var dir = it
-          endings.mapIt(path.join(dir, tool & it).cstring))
+          endings.mapIt(path.join(dir, tool & cstring(it))))
       .foldl(a & b)# flatten nested arays
       .filterIt(fs.existsSync(it))
 


### PR DESCRIPTION
Multiple warnings have been removed:
- Several instances of "duplicate import of 'strformat'"
- Several instances of "declared but not used"
- Several instances of "implicit conversion to 'cstring' from a non-const location"