### PR TITLE
Replaces the bell symbol by a blue underline for propagated exceptions

### DIFF
--- a/src/platform/languageClientApi.nim
+++ b/src/platform/languageClientApi.nim
@@ -10,7 +10,7 @@ type
   VscodeLanguageClientObj {.importc.} = object of JsRoot
   VscodeLanguageClientMiddleware* = ref VscodeLanguageClientMiddlewareObj
   VscodeLanguageClientMiddlewareObj {.importc.} = object of JsObject
-    provideInlayHints*: proc(document: JsObject, viewPort: JsObject, token: JsObject, next: JsObject): Promise[JsObject]
+    provideInlayHints*: proc(document: JsObject, viewPort: JsObject, token: JsObject, next: JsObject): Promise[seq[InlayHint]]
 
   TransportKind* {.pure.} = enum
     stdio = 0
@@ -42,6 +42,28 @@ type
   LanguageClientOptionsObj* {.importc.} = object of JsObject
     documentSelector*: seq[DocumentFilter]
     outputChannel*: VscodeOutputChannel
+  
+  InlayHint* = ref object of JsRoot
+    position*: VscodePosition
+    label*: cstring  # Can be string or InlayHintLabelPart[]
+    kind*: InlayHintKind
+    textEdits*: seq[VscodeTextEdit]
+    tooltip*: cstring
+    paddingLeft*: bool
+    paddingRight*: bool
+
+  InlayHintLabel* = ref object of JsRoot  # Union type: string | InlayHintLabelPart[]
+
+  InlayHintLabelPart* = ref object of JsRoot
+    value*: cstring
+    tooltip*: cstring
+    location*: VscodeLocation
+    command*: VscodeCommands
+
+  InlayHintKind* {.pure.} = enum
+    Type = 1
+    Parameter = 2
+
 
 proc newLanguageClient*(
   cl: VscodeLanguageClient,

--- a/src/platform/vscodeApi.nim
+++ b/src/platform/vscodeApi.nim
@@ -187,7 +187,7 @@ type
   VscodeMarkedString* = ref VscodeMarkedStringObj
   VscodeMarkedStringObj {.importc.} = object of JsObject
 
-  VscodeDecorationOptions* = ref object
+  VscodeDecorationOptions* = ref object of VscodeDisposable
     range*: VscodeRange
     hoverMessage*: cstring
     command*: VscodeCommands
@@ -592,8 +592,9 @@ type
     before*: VscodeThemableDecorationAttachmentRenderOptions
     gutterIconPath*: cstring
     gutterIconSize*: cstring
-
-
+    border*: cstring
+    textDecoration*: cstring
+    color*: cstring
   VscodeTextEditorDecorationType* = ref VscodeTextEditorDecorationTypeObj
   VscodeTextEditorDecorationTypeObj {.importc.} = object of JsObject
   

--- a/src/spec.nim
+++ b/src/spec.nim
@@ -1,5 +1,5 @@
 ## Types for extension state, this should either get fleshed out or removed
-import std/[options, times, strutils, jsconsole]
+import std/[options, times, strutils, jsconsole, tables]
 import platform/vscodeApi
 
 from platform/languageClientApi import VscodeLanguageClient
@@ -90,6 +90,7 @@ type
     lspVersion*: LSPVersion
     lspExtensionCapabilities*: set[LspExtensionCapability]
     nimbleTasks*: seq[NimbleTask]
+    propagatedDecorations*: Table[cstring, seq[VscodeTextEditorDecorationType]]
     
    
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8f5a6d69-2ec8-4437-af11-410eac34840d)
