### PR TITLE
Removes Command Show Nim Language Server Status #Fixes #129

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,10 +187,6 @@
                 "command": "nim.restartNimsuggest",
                 "title": "Restarts nimsuggest",
                 "category": "Nim"
-            },
-            {
-                "command": "nim.showNimLangServerStatus",
-                "title": "Show Nim Language Server Status"
             }
         ],
         "menus": {


### PR DESCRIPTION
No longer needed as it's part of the extension panel